### PR TITLE
Revert "Added the KomodoTS TorqueScript addon"

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -10,7 +10,6 @@ New Source Tree: https://github.com/HTD/NST
 exuberant Ctags support: https://github.com/agroszer/koctags
 qwin: https://github.com/agroszer/komodo-qwin
 Komodin Git: https://github.com/titoBouzout/komodo-komodin-git
-KomodoTS: https://github.com/elfprince13/KomodoTS
 SQLite Manager: https://github.com/lazierthanthou/sqlite-manager
 Quick Diff: https://github.com/tuomassalo/komodo-quickdiff
 SciViews-R: https://github.com/cran/svKomodo


### PR DESCRIPTION
It's already added to Languages: https://github.com/Komodo/Packages/blob/master/languages.yml#L3
Not sure there are some reasons to duplicate these addons.