### PR TITLE
addons.yml : added KoffeeLint

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+KoffeeLint: https://github.com/ervumlens/koffeelint
 Preference Spy: https://github.com/ervumlens/ko-preferencespy
 Style Spy: https://github.com/ervumlens/ko-stylespy
 Beautify js: https://github.com/babobski/Beautify-js


### PR DESCRIPTION
KoffeeLint is an add-on that calls CoffeeLint (installed separately) to perform linting on CoffeeScript files. Not much to it.