### PR TITLE
Added my relative includes widget

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+Relative Includes: https://github.com/babobski/relative-includes
 EOL widget: https://github.com/babobski/EOL-widget
 HTML Entities Pane: https://github.com/babobski/HTML-Entities
 FontAwesome Pane: https://github.com/babobski/FontAwesome 


### PR DESCRIPTION
Added my Relative Includes widget, based on the [userscript](http://code.activestate.com/recipes/577306-komodo-js-macro-insert-a-relative-path-from-the-cu/?in=lang-javascript) from @toddw-as, extended the function to also work on remotes, and added a function for generating a relative url from the base of the current project.
Made it in a widget so anyone can enjoy from this functionality, find this really convenient working on style or view files.