### PR TITLE
added the RGBA Colorpicker

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+RGBA Colorpicker: https://github.com/babobski/RGBA-Colorpicker
 Shutdown Settings: https://github.com/babobski/Shutdown-Settings
 Last Modified Files: https://github.com/babobski/Last-modified-files
 Relative Includes: https://github.com/babobski/relative-includes


### PR DESCRIPTION
Got the implementation of the RGBA colorpicker finished.
Build with the [colorPicker](https://github.com/PitPik/colorPicker)
Replaces the default colorpicker with a RGBA compatible colorpicker, lets you convert a hex color to a RGBA color and visa versa.