### PR TITLE
Added the Git for Windows addon

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+Git for Windows: https://github.com/babobski/Git-for-Windows
 Current Indent widget: https://github.com/babobski/Current-Indent-Widget
 Open in FileZilla: https://github.com/babobski/Open-In-FileZilla
 Side by Side: https://github.com/babobski/Side-By-Side


### PR DESCRIPTION
Added the Git for Windows addon, creates basic Git support for Komodo Edit/Ide on Windows.
The addon adds git commands in different context-menu's and adds a git toolbar-button with various git commands. Also you can set up you're key-bindings and the git menu is completely available trough you're access-keys.