### PR TITLE
Added the Find Window addon and 2 color-schemes

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+Find Window: https://github.com/babobski/Find-Window
 Close tabs to the right: https://github.com/babobski/Close-tabs-to-the-right
 Komodo Git: https://github.com/babobski/Komodo-Git
 Current Indent widget: https://github.com/babobski/Current-Indent-Widget

--- a/schemes.yml
+++ b/schemes.yml
@@ -50,6 +50,8 @@ Clasico: https://github.com/babobski/Clasico
 Unikitty: https://github.com/Defman21/komodo-unikitty
 Grey Storm: https://github.com/babobski/Grey-Storm
 Arc Red Dark: https://github.com/Naatan/Arc-Red-Dark-Komodo
+Winify Dark - Monokai: https://github.com/babobski/Winify-Dark-Monokai
+Winify Dark - Dracula: https://github.com/babobski/Winify-Dark-Dracula
 
 Base16 Collection:
   html_url: https://github.com/Komodo/base16-builder


### PR DESCRIPTION
Finished the Find Window addon. So for the people that want a popop find window there is a solution.
Showed the addon to a colleague today, but he didn't understand why I build the addon. He likes the docked find window better and I have to agree the docked find window is pretty need.

Also added two dark colors-schemes wich is a spotify/windows 10 mash-up, available in two different color schemes.