### PR TITLE
Removed color swatch addon, replaced the K11 Winify scheme

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -5,7 +5,6 @@ Komodo Git: https://github.com/babobski/Komodo-Git
 Current Indent widget: https://github.com/babobski/Current-Indent-Widget
 Open in FileZilla: https://github.com/babobski/Open-In-FileZilla
 Side by Side: https://github.com/babobski/Side-By-Side
-Old Color Swatch: https://github.com/babobski/Old-Color-Swatch
 RGBA Colorpicker: https://github.com/babobski/RGBA-Colorpicker
 Shutdown Settings: https://github.com/babobski/Shutdown-Settings
 Last Modified Files: https://github.com/babobski/Last-modified-files

--- a/schemes.yml
+++ b/schemes.yml
@@ -1,4 +1,4 @@
-K11 Winify Dark - Monokai: https://github.com/babobski/K11-Winify-Dark-Monokai
+K11 Darksome - Monokai: https://github.com/babobski/K11-Darksome-Monokai
 Dracula: https://github.com/babobski/Dracula-scheme
 Afterdawn: https://github.com/Defman21/afterdawn-komodo
 Blueland: https://github.com/Defman21/blueland-komodo


### PR DESCRIPTION
Removed the old color swatch addon, because it is obsolete.
Also replaced the K11 Winify scheme with the K11 Darksome - monokai color scheme.
It is basically the same scheme, only I dropped the Windows style window icons.