### PR TITLE
Added the open windows addon

### DIFF
--- a/addons.yml
+++ b/addons.yml
@@ -1,3 +1,4 @@
+Open Windows: https://github.com/babobski/Open-Windows
 Export-Import Servers: https://github.com/babobski/Export-Import-Servers
 Find Window: https://github.com/babobski/Find-Window
 Close tabs to the right: https://github.com/babobski/Close-tabs-to-the-right


### PR DESCRIPTION
Added the open windows addon, adds a side panel where you can easily switch between you're open Komodo Windows. Saw a [request](https://community.komodoide.com/t/window-list/3847) for a way to easily see and cycle trough you're open Komodo Windows.

![afbeelding](https://user-images.githubusercontent.com/3530262/33514375-1a75242e-d753-11e7-9ab4-c5f4d766bbe9.png)

I also work most of the time with multiple open Komodo windows, this addon makes it real easy to switch between you're open projects/windows.

Can you also give the Komodo Website a kick, it is stuck for a while now.